### PR TITLE
Replace DevExpress components with open source stack

### DIFF
--- a/FleetDesignTaxi.csproj
+++ b/FleetDesignTaxi.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>FleetDesignTaxi</RootNamespace>
+    <UserSecretsId>FleetDesignTaxi-Development</UserSecretsId>
+  </PropertyGroup>
+</Project>

--- a/Models/AutoServiceEntry.cs
+++ b/Models/AutoServiceEntry.cs
@@ -1,0 +1,14 @@
+namespace FleetDesignTaxi.Models;
+
+public record AutoServiceEntry(
+    string Vendor,
+    string ServiceType,
+    string Vehicle,
+    string Registration,
+    string Contact,
+    string Email,
+    string Status,
+    DateTime LastService,
+    DateTime NextService,
+    decimal Cost
+);

--- a/Models/DashboardModels.cs
+++ b/Models/DashboardModels.cs
@@ -1,0 +1,9 @@
+namespace FleetDesignTaxi.Models;
+
+public record TransactionRecord(string Route, int Trips, int Completed, int Cancelled, decimal Revenue);
+
+public record SmsAlert(string Recipient, string Category, string Message, string Status, DateTime SentAt);
+
+public record NewsItem(string Title, string Category, DateTime PublishedOn, string Summary, string Link);
+
+public record RevenuePoint(DateTime Date, decimal Amount);

--- a/Pages/AutoServices.cshtml
+++ b/Pages/AutoServices.cshtml
@@ -1,0 +1,93 @@
+@page
+@model FleetDesignTaxi.Pages.AutoServicesModel
+
+<section class="fade-in">
+    <div class="glass-card">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+            <div>
+                <h2 class="h4 text-white mb-1">Auto Services</h2>
+                <p class="text-white-50 mb-0">Monitor vendor performance, cadence and spend from a single command center.</p>
+            </div>
+            <div class="d-flex gap-2">
+                <button class="btn btn-outline-light">Export</button>
+                <button class="btn btn-azure text-white">Schedule Service</button>
+            </div>
+        </div>
+        <div class="table-glass">
+            <table id="autoServicesTable" class="table table-dark table-hover table-striped align-middle mb-0 autoservices-table" aria-describedby="autoServicesCaption">
+                <caption id="autoServicesCaption" class="visually-hidden">Vendor auto services roster</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Vendor</th>
+                        <th scope="col">Service Type</th>
+                        <th scope="col">Vehicle</th>
+                        <th scope="col">Registration</th>
+                        <th scope="col">Contact</th>
+                        <th scope="col">Email</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Last Service</th>
+                        <th scope="col">Next Service</th>
+                        <th scope="col" class="text-end">Cost</th>
+                        <th scope="col" class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var service in Model.Services)
+                    {
+                        var statusClass = service.Status.ToLowerInvariant().Replace(" ", "-");
+                        <tr>
+                            <th scope="row" class="fw-semibold">@service.Vendor</th>
+                            <td>@service.ServiceType</td>
+                            <td>@service.Vehicle</td>
+                            <td>@service.Registration</td>
+                            <td>@service.Contact</td>
+                            <td><a href="mailto:@service.Email" class="link-light">@service.Email</a></td>
+                            <td>
+                                <span class="status-chip status-@statusClass">@service.Status</span>
+                            </td>
+                            <td>@service.LastService.ToLocalTime().ToString("MMM dd, yyyy")</td>
+                            <td>@service.NextService.ToLocalTime().ToString("MMM dd, yyyy")</td>
+                            <td class="text-end">@service.Cost.ToString("C0")</td>
+                            <td class="text-center">
+                                <div class="row-actions">
+                                    <button type="button" class="icon-btn" title="Edit service" aria-label="Edit service">
+                                        <i class="bi bi-pencil" aria-hidden="true"></i>
+                                    </button>
+                                    <button type="button" class="icon-btn icon-btn-danger" title="Delete service" aria-label="Delete service">
+                                        <i class="bi bi-trash" aria-hidden="true"></i>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const table = document.getElementById('autoServicesTable');
+            if (!table) {
+                return;
+            }
+
+            $(table).DataTable({
+                dom: "<'row align-items-center mb-3'<'col-lg-6'l><'col-lg-6'f>>t<'row align-items-center mt-3'<'col-md-6'i><'col-md-6'p>>",
+                pageLength: 10,
+                lengthMenu: [10, 20, 50],
+                order: [[7, 'desc']],
+                columnDefs: [
+                    { targets: -1, orderable: false, searchable: false },
+                    { targets: 6, orderable: false }
+                ],
+                language: {
+                    search: '',
+                    searchPlaceholder: 'Search services…',
+                    lengthMenu: 'Show _MENU_ entries'
+                }
+            });
+        });
+    </script>
+}

--- a/Pages/AutoServices.cshtml.cs
+++ b/Pages/AutoServices.cshtml.cs
@@ -1,0 +1,24 @@
+using FleetDesignTaxi.Models;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FleetDesignTaxi.Pages;
+
+public class AutoServicesModel : PageModel
+{
+    public IReadOnlyList<AutoServiceEntry> Services { get; private set; } = Array.Empty<AutoServiceEntry>();
+
+    public void OnGet()
+    {
+        Services = new List<AutoServiceEntry>
+        {
+            new("Autofix Labs", "Battery Diagnostics", "EV-204", "TX-9821", "Kyla Flores", "service@autofix.io", "Active", DateTime.UtcNow.AddDays(-17), DateTime.UtcNow.AddDays(13), 4200m),
+            new("Metro Motors", "Brake Calibration", "SUV-114", "TX-7782", "Miguel Costa", "metro@motors.com", "Active", DateTime.UtcNow.AddDays(-33), DateTime.UtcNow.AddDays(27), 1680m),
+            new("Urban Detailers", "Interior Detox", "Sedan-452", "TX-2345", "Aisha Rahim", "hello@urbandetailers.com", "Archived", DateTime.UtcNow.AddDays(-80), DateTime.UtcNow.AddDays(-10), 350m),
+            new("Skyline Workshop", "Suspension Overhaul", "SUV-834", "TX-6543", "Jonah Bishop", "contact@skylineworkshop.com", "Active", DateTime.UtcNow.AddDays(-12), DateTime.UtcNow.AddDays(40), 2680m),
+            new("Quantum Lube", "Oil Replacement", "Sedan-298", "TX-9043", "Ada Mendez", "ops@quantumlube.com", "Not Active", DateTime.UtcNow.AddDays(-120), DateTime.UtcNow.AddDays(-20), 220m),
+            new("Prime Auto Care", "Telematics Retrofit", "EV-390", "TX-3321", "Lee Carter", "support@primeauto.com", "Active", DateTime.UtcNow.AddDays(-5), DateTime.UtcNow.AddDays(50), 5200m)
+        };
+
+        ViewData["Title"] = "Auto Services";
+    }
+}

--- a/Pages/Error.cshtml
+++ b/Pages/Error.cshtml
@@ -1,0 +1,10 @@
+@page
+@model Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+@{
+    ViewData["Title"] = "Error";
+}
+<div class="container py-5 text-center text-white">
+    <h1 class="display-5 fw-bold">Something went wrong</h1>
+    <p class="lead text-white-50">Our engineers have been notified. Please retry the action.</p>
+    <a class="btn btn-azure" href="@Url.Page("/Index")">Return to Dashboard</a>
+</div>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -1,0 +1,226 @@
+@page
+@using System.Text.Json
+@model FleetDesignTaxi.Pages.IndexModel
+
+<section class="row g-4 fade-in">
+    <article class="col-12 col-xl-6">
+        <div class="glass-card h-100">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <h2 class="h5 text-white mb-1">Transaction Data</h2>
+                    <p class="text-white-50 small mb-0">Live trip outcomes across all premium routes</p>
+                </div>
+                <span class="badge bg-azure">Updated 5 min ago</span>
+            </div>
+            <div class="table-glass">
+                <table id="transactionsTable" class="table table-dark table-hover table-striped align-middle mb-0" aria-describedby="transactionsCaption">
+                    <caption id="transactionsCaption" class="visually-hidden">Recent transaction performance</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Route</th>
+                            <th scope="col" class="text-center">Trips</th>
+                            <th scope="col" class="text-center">Completed</th>
+                            <th scope="col" class="text-center">Cancelled</th>
+                            <th scope="col" class="text-end">Revenue</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var record in Model.Transactions)
+                        {
+                            <tr>
+                                <th scope="row" class="fw-semibold">@record.Route</th>
+                                <td class="text-center">@record.Trips</td>
+                                <td class="text-center">@record.Completed</td>
+                                <td class="text-center">@record.Cancelled</td>
+                                <td class="text-end">@record.Revenue.ToString("C0")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </article>
+    <article class="col-12 col-xl-6">
+        <div class="glass-card h-100">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <h2 class="h5 text-white mb-1">News</h2>
+                    <p class="text-white-50 small mb-0">Strategic announcements curated for operations leaders</p>
+                </div>
+                <a class="card-link link-muted" href="#">View all <i class="bi bi-chevron-right" aria-hidden="true"></i></a>
+            </div>
+            <div class="vstack gap-3">
+                @foreach (var news in Model.News)
+                {
+                    <div class="p-3 rounded-4" style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.05);">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <span class="badge rounded-pill" style="background: rgba(47,128,237,0.2); color: var(--color-azure);">@news.Category</span>
+                            <small class="text-white-50">@news.PublishedOn.ToString("MMM dd")</small>
+                        </div>
+                        <h3 class="h6 text-white mt-2 mb-1">@news.Title</h3>
+                        <p class="text-white-50 mb-2">@news.Summary</p>
+                        <a class="card-link" href="@news.Link" target="_blank" rel="noopener">Read report <i class="bi bi-arrow-right" aria-hidden="true"></i></a>
+                    </div>
+                }
+            </div>
+        </div>
+    </article>
+    <article class="col-12 col-xl-6">
+        <div class="glass-card h-100">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <h2 class="h5 text-white mb-1">SMSs</h2>
+                    <p class="text-white-50 small mb-0">Critical communications across the fleet ecosystem</p>
+                </div>
+                <div class="badge bg-emerald text-uppercase">Synced</div>
+            </div>
+            <div class="table-glass">
+                <table id="smsTable" class="table table-dark table-hover table-striped align-middle mb-0" aria-describedby="smsCaption">
+                    <caption id="smsCaption" class="visually-hidden">Recent SMS alerts</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Recipient</th>
+                            <th scope="col">Category</th>
+                            <th scope="col">Message</th>
+                            <th scope="col">Status</th>
+                            <th scope="col" class="text-end">Sent</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var sms in Model.SmsAlerts)
+                        {
+                            <tr>
+                                <th scope="row" class="fw-semibold">@sms.Recipient</th>
+                                <td>@sms.Category</td>
+                                <td class="text-white-50">@sms.Message</td>
+                                <td>@sms.Status</td>
+                                <td class="text-end">@sms.SentAt.ToLocalTime().ToString("HH:mm")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </article>
+    <article class="col-12 col-xl-6">
+        <div class="glass-card h-100">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <h2 class="h5 text-white mb-1">Revenue</h2>
+                    <p class="text-white-50 small mb-0">Rolling 12-month net revenue trend</p>
+                </div>
+                <a class="card-link link-muted" href="#">Download CSV <i class="bi bi-download" aria-hidden="true"></i></a>
+            </div>
+            <div class="revenue-chart-container">
+                <canvas id="revenueChart" role="img" aria-label="Revenue trend chart"></canvas>
+            </div>
+        </div>
+    </article>
+</section>
+
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const transactionTable = document.getElementById('transactionsTable');
+            if (transactionTable) {
+                $(transactionTable).DataTable({
+                    dom: 't',
+                    paging: false,
+                    searching: false,
+                    info: false,
+                    ordering: false
+                });
+            }
+
+            const smsTable = document.getElementById('smsTable');
+            if (smsTable) {
+                $(smsTable).DataTable({
+                    dom: 't',
+                    paging: false,
+                    searching: false,
+                    info: false,
+                    ordering: false
+                });
+            }
+
+            const chartElement = document.getElementById('revenueChart');
+            if (chartElement) {
+                const context = chartElement.getContext('2d');
+                const gradient = context.createLinearGradient(0, 0, 0, chartElement.offsetHeight || 320);
+                gradient.addColorStop(0, 'rgba(47, 128, 237, 0.55)');
+                gradient.addColorStop(1, 'rgba(39, 174, 96, 0.2)');
+
+                const revenueData = @Html.Raw(JsonSerializer.Serialize(new
+                {
+                    labels = Model.RevenueSeries.Select(point => point.Date.ToString("MMM yyyy")),
+                    data = Model.RevenueSeries.Select(point => point.Amount)
+                }));
+
+                new Chart(chartElement, {
+                    type: 'line',
+                    data: {
+                        labels: revenueData.labels,
+                        datasets: [{
+                            label: 'Revenue',
+                            data: revenueData.data,
+                            fill: true,
+                            backgroundColor: gradient,
+                            borderColor: '#2F80ED',
+                            borderWidth: 2,
+                            pointBackgroundColor: '#27AE60',
+                            pointBorderColor: '#0C1F2D',
+                            pointRadius: 4,
+                            tension: 0.35
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        interaction: { mode: 'index', intersect: false },
+                        plugins: {
+                            legend: {
+                                labels: {
+                                    color: '#ECF0F1',
+                                    font: { family: 'Inter, sans-serif' }
+                                }
+                            },
+                            tooltip: {
+                                backgroundColor: 'rgba(12, 31, 45, 0.85)',
+                                titleColor: '#ECF0F1',
+                                bodyColor: '#ECF0F1',
+                                borderColor: 'rgba(236, 240, 241, 0.15)',
+                                borderWidth: 1,
+                                displayColors: false,
+                                callbacks: {
+                                    label: function (context) {
+                                        const value = context.parsed.y || 0;
+                                        return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            x: {
+                                grid: { color: 'rgba(255, 255, 255, 0.08)' },
+                                ticks: { color: '#ECF0F1' }
+                            },
+                            y: {
+                                grid: { color: 'rgba(255, 255, 255, 0.08)' },
+                                ticks: {
+                                    color: '#ECF0F1',
+                                    callback: function (value) {
+                                        return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+                                    }
+                                }
+                            }
+                        },
+                        animation: {
+                            duration: 800,
+                            easing: 'easeInOutQuad'
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+}

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,0 +1,44 @@
+using FleetDesignTaxi.Models;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FleetDesignTaxi.Pages;
+
+public class IndexModel : PageModel
+{
+    public IReadOnlyList<TransactionRecord> Transactions { get; private set; } = Array.Empty<TransactionRecord>();
+    public IReadOnlyList<SmsAlert> SmsAlerts { get; private set; } = Array.Empty<SmsAlert>();
+    public IReadOnlyList<NewsItem> News { get; private set; } = Array.Empty<NewsItem>();
+    public IReadOnlyList<RevenuePoint> RevenueSeries { get; private set; } = Array.Empty<RevenuePoint>();
+
+    public void OnGet()
+    {
+        Transactions = new List<TransactionRecord>
+        {
+            new("Urban Core Loop", 128, 122, 6, 18320m),
+            new("Airport Express", 94, 90, 4, 15240m),
+            new("Night Line", 64, 60, 4, 9800m),
+            new("Suburban Connector", 76, 74, 2, 11260m)
+        };
+
+        SmsAlerts = new List<SmsAlert>
+        {
+            new("Dispatch Team", "System", "Telematics sync completed", "Delivered", DateTime.UtcNow.AddMinutes(-12)),
+            new("Driver 204", "Compliance", "Inspection due in 48 hours", "Queued", DateTime.UtcNow.AddMinutes(-45)),
+            new("Maintenance HQ", "Maintenance", "EV battery health check scheduled", "Delivered", DateTime.UtcNow.AddHours(-3)),
+            new("Driver 118", "Operations", "Route detour activated", "Delivered", DateTime.UtcNow.AddHours(-6))
+        };
+
+        News = new List<NewsItem>
+        {
+            new("Fleet AI copilots reduce idle time by 18%", "Product Update", DateTime.UtcNow.AddDays(-1), "Predictive routing deployed to all premium fleets", "https://example.com/news/ai-copilots"),
+            new("Regional compliance bulletin Q2", "Compliance", DateTime.UtcNow.AddDays(-3), "Updated taxi licensing requirements and documentation checklist", "https://example.com/news/compliance-q2"),
+            new("Operations leadership summit announced", "Events", DateTime.UtcNow.AddDays(-5), "Join the annual strategy session with peers across global fleets", "https://example.com/news/summit")
+        };
+
+        RevenueSeries = Enumerable.Range(0, 12)
+            .Select(offset => new RevenuePoint(DateTime.UtcNow.Date.AddMonths(-11 + offset), 9500m + offset * 850m))
+            .ToList();
+
+        ViewData["Title"] = "Dashboard";
+    }
+}

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -1,0 +1,32 @@
+@page
+@model FleetDesignTaxi.Pages.SettingsModel
+
+<section class="fade-in">
+    <div class="row g-4">
+        @foreach (var section in Model.Sections)
+        {
+            <div class="col-12 col-md-6 col-xl-3 d-flex">
+                <div class="glass-card w-100 settings-panel">
+                    <header class="card-header-accent">
+                        <span class="accent-dot accent-@section.Accent"></span>
+                        <div>
+                            <h2 class="h6 text-white mb-1">@section.Title</h2>
+                            <p class="text-white-50 mb-0 small">@section.Description</p>
+                        </div>
+                    </header>
+                    <ul class="list-unstyled vstack gap-2 mb-0">
+                        @foreach (var link in section.Links)
+                        {
+                            <li>
+                                <a class="card-link" href="@link.Url">
+                                    <i class="bi @link.IconClass" aria-hidden="true"></i>
+                                    <span>@link.Label</span>
+                                </a>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            </div>
+        }
+    </div>
+</section>

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FleetDesignTaxi.Pages;
+
+public class SettingsModel : PageModel
+{
+    public record SettingSection(string Title, string Accent, string Description, IEnumerable<SettingLink> Links);
+    public record SettingLink(string Label, string Url, string IconClass);
+
+    public IReadOnlyList<SettingSection> Sections { get; private set; } = Array.Empty<SettingSection>();
+
+    public void OnGet()
+    {
+        Sections = new List<SettingSection>
+        {
+            new("Vehicle Setting", "azure", "Manage fleet vehicle archetypes, classes and telematics tags", new []
+            {
+                new SettingLink("Vehicle Types", "#", "bi-car-front"),
+                new SettingLink("Taxi Tags", "#", "bi-tags"),
+                new SettingLink("Vehicle Group", "#", "bi-diagram-3"),
+                new SettingLink("Driver Pool", "#", "bi-people"),
+                new SettingLink("Employee Card", "#", "bi-credit-card-2-front")
+            }),
+            new("Accident Setting", "amber", "Standardize emergency protocols and field reporting flows", new []
+            {
+                new SettingLink("Police Protocol", "#", "bi-shield-exclamation"),
+                new SettingLink("Claim Forms", "#", "bi-file-earmark-text"),
+                new SettingLink("Incident Templates", "#", "bi-journal-text"),
+                new SettingLink("Response Contacts", "#", "bi-telephone-forward"),
+            }),
+            new("General Setting", "emerald", "Organization-wide tax, billing and integration preferences", new []
+            {
+                new SettingLink("Company Segments", "#", "bi-pie-chart"),
+                new SettingLink("Gateway Keys", "#", "bi-key"),
+                new SettingLink("Data Provider", "#", "bi-hdd-network"),
+                new SettingLink("Notification Center", "#", "bi-bell"),
+            }),
+            new("Vehicle Maintenance", "azure", "Plan service cadences, warranties and component upgrades", new []
+            {
+                new SettingLink("Inventory", "#", "bi-box-seam"),
+                new SettingLink("Work Orders", "#", "bi-clipboard-check"),
+                new SettingLink("Service Level", "#", "bi-speedometer"),
+                new SettingLink("Vendor Ledger", "#", "bi-receipt"),
+            })
+        };
+
+        ViewData["Title"] = "Settings";
+    }
+}

--- a/Pages/Shared/_Header.cshtml
+++ b/Pages/Shared/_Header.cshtml
@@ -1,0 +1,29 @@
+<header class="app-header d-flex align-items-center justify-content-between px-4 py-3">
+    <div class="d-flex align-items-center gap-3">
+        <button class="btn btn-link text-decoration-none text-white d-lg-none" type="button" data-sidebar-toggle aria-controls="sidebarPanel" aria-expanded="false">
+            <i class="bi bi-list" aria-hidden="true"></i>
+        </button>
+        <div>
+            <h1 class="h5 mb-0 text-white">@ViewData["Title"]</h1>
+            <p class="text-white-50 mb-0 small">Real-time visibility into fleet operations</p>
+        </div>
+    </div>
+    <div class="d-flex align-items-center gap-3">
+        <div class="badge bg-azure text-uppercase">Enterprise</div>
+        <div class="dropdown">
+            <button class="btn btn-outline-light rounded-pill px-3 d-flex align-items-center gap-2" id="userMenu" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="avatar-initials">MC</span>
+                <span class="text-start">
+                    <span class="d-block fw-semibold">Morgan Chen</span>
+                    <small class="text-white-50">Operations Lead</small>
+                </span>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end shadow-lg" aria-labelledby="userMenu">
+                <li><a class="dropdown-item" href="#">Profile</a></li>
+                <li><a class="dropdown-item" href="#">Notifications</a></li>
+                <li><hr class="dropdown-divider" /></li>
+                <li><a class="dropdown-item text-danger" href="#">Sign out</a></li>
+            </ul>
+        </div>
+    </div>
+</header>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,38 @@
+@{
+    var pageTitle = ViewData["Title"] as string ?? "Fleet Command Center";
+}
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@pageTitle - Fleet Design Taxi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
+    <link href="https://cdn.datatables.net/1.13.8/css/dataTables.bootstrap5.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body class="app-shell">
+    <div class="app-wrapper d-flex">
+        <partial name="~/Pages/Shared/_Sidebar.cshtml" />
+        <div class="app-main flex-grow-1 d-flex flex-column">
+            <partial name="~/Pages/Shared/_Header.cshtml" />
+            <main role="main" class="app-content flex-grow-1 overflow-auto">
+                <div class="container-fluid py-4 px-4 px-lg-5">
+                    @RenderBody()
+                </div>
+            </main>
+        </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.8/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/Pages/Shared/_Sidebar.cshtml
+++ b/Pages/Shared/_Sidebar.cshtml
@@ -1,0 +1,34 @@
+@{
+    var currentPath = ViewContext.HttpContext.Request.Path.Value?.TrimEnd('/')?.ToLowerInvariant() ?? string.Empty;
+    if (string.IsNullOrWhiteSpace(currentPath))
+    {
+        currentPath = "/";
+    }
+
+    var navigation = new[]
+    {
+        new { Title = "Dashboard", Icon = "bi-speedometer2", Page = "/Index", Matches = new []{"/", "/index"} },
+        new { Title = "Settings", Icon = "bi-sliders", Page = "/Settings", Matches = new []{"/settings"} },
+        new { Title = "Auto Services", Icon = "bi-ev-front", Page = "/AutoServices", Matches = new []{"/autoservices"} }
+    };
+}
+<aside id="sidebarPanel" class="app-sidebar d-flex flex-column align-items-stretch">
+    <div class="sidebar-logo text-center py-4">
+        <span class="fw-bold text-uppercase tracking-wide text-white">Fleet<span class="text-azure">Command</span></span>
+    </div>
+    <div class="flex-grow-1 overflow-auto px-3">
+        <nav class="sidebar-nav nav flex-column gap-2" aria-label="Primary">
+            @foreach (var item in navigation)
+            {
+                var isActive = Array.IndexOf(item.Matches, currentPath) >= 0;
+                <a asp-page="@item.Page" class="nav-link sidebar-link @(isActive ? "active" : string.Empty)" aria-current="@(isActive ? "page" : null)">
+                    <i class="bi @item.Icon" aria-hidden="true"></i>
+                    <span>@item.Title</span>
+                </a>
+            }
+        </nav>
+    </div>
+    <div class="sidebar-footer text-center text-white-50 small py-3">
+        <span>&copy; @DateTime.UtcNow.Year Fleet Command Center</span>
+    </div>
+</aside>

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using FleetDesignTaxi
+@namespace FleetDesignTaxi.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/Pages/_ViewStart.cshtml
+++ b/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "~/Pages/Shared/_Layout.cshtml";
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,19 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.UseAuthorization();
+app.MapRazorPages();
+
+app.Run();

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "FleetDesignTaxi": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,0 +1,486 @@
+/*
+    Global visual system for Fleet Command Center
+    -------------------------------------------------
+    - Dark navy gradient backdrop with glass morphism panels
+    - Data-rich tables and charts theming overrides
+*/
+:root {
+    --color-background-start: #0C1F2D;
+    --color-background-end: #1E3A5F;
+    --color-layer-dark: #2C3E50;
+    --color-layer-soft: #34495E;
+    --color-azure: #2F80ED;
+    --color-emerald: #27AE60;
+    --color-amber: #F2C94C;
+    --color-text: #ECF0F1;
+    --transition-base: 200ms ease;
+    font-size: 16px;
+}
+
+html, body {
+    height: 100%;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(135deg, var(--color-background-start), var(--color-background-end));
+    color: var(--color-text);
+}
+
+body.app-shell {
+    margin: 0;
+    display: flex;
+}
+
+.app-wrapper {
+    min-height: 100vh;
+    width: 100%;
+}
+
+.app-sidebar {
+    width: 260px;
+    background: linear-gradient(160deg, rgba(12, 31, 45, 0.95), rgba(30, 58, 95, 0.88));
+    backdrop-filter: blur(14px);
+    box-shadow: 0 0 25px rgba(12, 31, 45, 0.6);
+    border-right: 1px solid rgba(255, 255, 255, 0.08);
+    position: sticky;
+    top: 0;
+}
+
+.sidebar-logo {
+    letter-spacing: 0.28em;
+    text-shadow: 0 0 10px rgba(47, 128, 237, 0.4);
+}
+
+.text-azure {
+    color: var(--color-azure) !important;
+}
+
+.sidebar-nav .sidebar-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.9rem 1rem;
+    border-radius: 12px;
+    color: rgba(255, 255, 255, 0.82);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    transition: background-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base), color var(--transition-base);
+}
+
+.sidebar-nav .sidebar-link .bi {
+    font-size: 1.15rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.sidebar-nav .sidebar-link:hover {
+    color: #fff;
+    background: rgba(47, 128, 237, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(47, 128, 237, 0.35), 0 8px 20px rgba(12, 31, 45, 0.45);
+    transform: translateX(4px);
+}
+
+.sidebar-nav .sidebar-link:hover .bi {
+    color: var(--color-azure);
+    text-shadow: 0 0 12px rgba(47, 128, 237, 0.45);
+}
+
+.sidebar-nav .sidebar-link.active {
+    color: #fff;
+    background: rgba(39, 174, 96, 0.25);
+    border-left: 4px solid var(--color-emerald);
+    box-shadow: inset 0 0 0 1px rgba(39, 174, 96, 0.35);
+}
+
+.sidebar-nav .sidebar-link.active .bi {
+    color: var(--color-emerald);
+    text-shadow: 0 0 12px rgba(39, 174, 96, 0.45);
+}
+
+.sidebar-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.app-main {
+    background: linear-gradient(160deg, rgba(12, 31, 45, 0.85), rgba(30, 58, 95, 0.95));
+    backdrop-filter: blur(12px);
+}
+
+.app-header {
+    background: rgba(44, 62, 80, 0.65);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(16px);
+    box-shadow: 0 12px 35px rgba(12, 31, 45, 0.45);
+}
+
+.app-content {
+    background: transparent;
+}
+
+.badge.bg-azure {
+    background-color: rgba(47, 128, 237, 0.2);
+    color: var(--color-azure);
+    border: 1px solid rgba(47, 128, 237, 0.4);
+}
+
+.avatar-initials {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(47, 128, 237, 0.75), rgba(39, 174, 96, 0.75));
+    color: #fff;
+    font-weight: 600;
+}
+
+.glass-card {
+    position: relative;
+    border-radius: 20px;
+    background: linear-gradient(145deg, rgba(44, 62, 80, 0.68), rgba(52, 73, 94, 0.55));
+    box-shadow: 0 25px 45px rgba(12, 31, 45, 0.4);
+    backdrop-filter: blur(18px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 1.5rem;
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.glass-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 35px 55px rgba(12, 31, 45, 0.55);
+}
+
+.card-header-accent {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding-bottom: 0.25rem;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid rgba(255, 255, 255, 0.12);
+}
+
+.card-header-accent .accent-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 999px;
+}
+
+.card-link {
+    color: inherit;
+    position: relative;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    transition: color var(--transition-base);
+}
+
+.card-link::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 100%;
+    height: 2px;
+    background: currentColor;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--transition-base);
+}
+
+.card-link:hover::after {
+    transform: scaleX(1);
+}
+
+.card-link .bi {
+    font-size: 0.95rem;
+}
+
+.table-glass {
+    background: rgba(12, 31, 45, 0.55);
+    border-radius: 20px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 18px 38px rgba(12, 31, 45, 0.35);
+}
+
+.table-glass .table {
+    color: var(--color-text);
+    margin-bottom: 0;
+}
+
+.table-glass .table caption {
+    caption-side: bottom;
+    color: rgba(255, 255, 255, 0.45);
+    padding-top: 0.75rem;
+    font-size: 0.85rem;
+}
+
+.table-glass .table thead th {
+    background-color: rgba(12, 31, 45, 0.75);
+    color: var(--color-text);
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+.table-glass .table tbody tr:nth-of-type(odd) {
+    background-color: rgba(44, 62, 80, 0.4);
+}
+
+.table-glass .table tbody tr:hover {
+    background-color: rgba(47, 128, 237, 0.16);
+    box-shadow: inset 0 0 0 1px rgba(47, 128, 237, 0.35);
+}
+
+.table-glass .table td,
+.table-glass .table th {
+    border-color: rgba(255, 255, 255, 0.08);
+    vertical-align: middle;
+}
+
+.table-glass .table a {
+    color: var(--color-azure);
+    text-decoration: none;
+}
+
+.table-glass .table a:hover {
+    text-decoration: underline;
+}
+
+.dataTables_wrapper .dataTables_filter,
+.dataTables_wrapper .dataTables_length {
+    color: rgba(255, 255, 255, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.72rem;
+}
+
+.dataTables_wrapper .dataTables_filter label,
+.dataTables_wrapper .dataTables_length label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0;
+}
+
+.dataTables_wrapper .dataTables_filter input,
+.dataTables_wrapper .dataTables_length select {
+    background: rgba(12, 31, 45, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 999px;
+    color: var(--color-text);
+    padding: 0.35rem 0.85rem;
+    outline: none;
+    transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.dataTables_wrapper .dataTables_filter input:focus,
+.dataTables_wrapper .dataTables_length select:focus {
+    border-color: rgba(47, 128, 237, 0.6);
+    box-shadow: 0 0 0 3px rgba(47, 128, 237, 0.25);
+}
+
+.dataTables_wrapper .dataTables_filter input::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.dataTables_wrapper .dataTables_info {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.8rem;
+}
+
+.dataTables_wrapper .dataTables_paginate {
+    margin-top: 0.5rem;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+    color: rgba(255, 255, 255, 0.75) !important;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    margin: 0 0.1rem;
+    padding: 0.35rem 0.85rem;
+    transition: background-color var(--transition-base), color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+    background: rgba(47, 128, 237, 0.22);
+    color: #fff !important;
+    box-shadow: 0 0 12px rgba(47, 128, 237, 0.35);
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current {
+    background: rgba(39, 174, 96, 0.35);
+    color: #fff !important;
+    box-shadow: 0 0 12px rgba(39, 174, 96, 0.35);
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+}
+
+.status-active {
+    background: rgba(39, 174, 96, 0.25);
+    color: #7ee0a7;
+    box-shadow: inset 0 0 0 1px rgba(39, 174, 96, 0.45);
+}
+
+.status-archived {
+    background: rgba(52, 73, 94, 0.35);
+    color: #aeb9c6;
+    box-shadow: inset 0 0 0 1px rgba(52, 73, 94, 0.55);
+}
+
+.status-inactive,
+.status-not-active {
+    background: rgba(242, 201, 76, 0.25);
+    color: #f9d87f;
+    box-shadow: inset 0 0 0 1px rgba(242, 201, 76, 0.45);
+}
+
+
+.revenue-chart-container {
+    position: relative;
+    height: 320px;
+}
+
+.revenue-chart-container canvas {
+    width: 100% !important;
+    height: 100% !important;
+    filter: drop-shadow(0 20px 40px rgba(39, 174, 96, 0.25));
+}
+
+.link-muted {
+    color: rgba(255, 255, 255, 0.55);
+}
+
+a.link-light {
+    color: var(--color-azure);
+    text-decoration: underline;
+    text-decoration-color: rgba(47, 128, 237, 0.4);
+    transition: color var(--transition-base), text-decoration-color var(--transition-base);
+}
+
+a.link-light:hover {
+    color: #fff;
+    text-decoration-color: rgba(255, 255, 255, 0.8);
+}
+
+.fade-in {
+    animation: fadeIn 350ms ease-in forwards;
+    opacity: 0;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 991.98px) {
+    .app-sidebar {
+        position: fixed;
+        inset: 0 auto 0 0;
+        z-index: 1045;
+        transform: translateX(-100%);
+        transition: transform var(--transition-base);
+    }
+}
+
+.accent-azure {
+    background: var(--color-azure);
+    box-shadow: 0 0 12px rgba(47, 128, 237, 0.45);
+}
+
+.accent-emerald {
+    background: var(--color-emerald);
+    box-shadow: 0 0 12px rgba(39, 174, 96, 0.45);
+}
+
+.accent-amber {
+    background: var(--color-amber);
+    box-shadow: 0 0 12px rgba(242, 201, 76, 0.35);
+}
+
+.badge.bg-emerald {
+    background-color: rgba(39, 174, 96, 0.25);
+    color: var(--color-text);
+    border: 1px solid rgba(39, 174, 96, 0.45);
+}
+
+.sidebar-open {
+    transform: translateX(0) !important;
+}
+
+.btn-azure {
+    background: linear-gradient(135deg, rgba(47, 128, 237, 0.85), rgba(47, 128, 237, 0.65));
+    border-color: rgba(47, 128, 237, 0.9);
+    transition: background var(--transition-base), box-shadow var(--transition-base);
+}
+
+.btn-azure:hover {
+    background: linear-gradient(135deg, rgba(47, 128, 237, 1), rgba(39, 174, 96, 0.85));
+    box-shadow: 0 10px 20px rgba(47, 128, 237, 0.35);
+}
+
+.autoservices-table tbody tr {
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.autoservices-table tbody tr:hover {
+    transform: translateY(-2px);
+    box-shadow: inset 0 0 0 1px rgba(39, 174, 96, 0.35);
+}
+
+.autoservices-table .row-actions {
+    display: inline-flex;
+    justify-content: center;
+    gap: 0.5rem;
+    opacity: 0;
+    transform: translateY(-6px);
+    transition: opacity var(--transition-base), transform var(--transition-base);
+}
+
+.autoservices-table tbody tr:hover .row-actions {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.icon-btn {
+    background: rgba(52, 73, 94, 0.65);
+    border-radius: 999px;
+    border: none;
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--color-text);
+    transition: background var(--transition-base), box-shadow var(--transition-base), color var(--transition-base);
+}
+
+.icon-btn:hover {
+    background: rgba(47, 128, 237, 0.75);
+    color: #fff;
+    box-shadow: 0 0 14px rgba(47, 128, 237, 0.35);
+}
+
+.icon-btn-danger:hover {
+    background: rgba(242, 201, 76, 0.7);
+    color: #0C1F2D;
+    box-shadow: 0 0 18px rgba(242, 201, 76, 0.4);
+}
+
+.tracking-wide {
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+}

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,0 +1,22 @@
+// Fleet Command Center interactions
+// ---------------------------------
+(() => {
+    document.addEventListener('DOMContentLoaded', () => {
+        const sidebar = document.getElementById('sidebarPanel');
+        const toggleButton = document.querySelector('[data-sidebar-toggle]');
+
+        if (sidebar && toggleButton) {
+            toggleButton.addEventListener('click', () => {
+                const isOpen = sidebar.classList.toggle('sidebar-open');
+                toggleButton.setAttribute('aria-expanded', isOpen.toString());
+            });
+
+            window.addEventListener('resize', () => {
+                if (window.innerWidth >= 992 && sidebar.classList.contains('sidebar-open')) {
+                    sidebar.classList.remove('sidebar-open');
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                }
+            });
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- remove DevExpress package dependencies and middleware registration so the project builds without a commercial license
- rebuild the shared layout, sidebar, and Razor pages to use Bootstrap, DataTables, and Chart.js in place of DevExpress grids and charts
- enhance the custom CSS/JS to theme the new open-source components with the existing glassmorphic SaaS aesthetic

## Testing
- not run (container lacks the .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68ca554e0adc832fbb0d86c37972ce1d